### PR TITLE
Updating the version check to pull it's version from the package.json

### DIFF
--- a/test/execution/rulesEngineInternalFunctions/rulesEngineInternalFunctions.t.sol
+++ b/test/execution/rulesEngineInternalFunctions/rulesEngineInternalFunctions.t.sol
@@ -1744,7 +1744,7 @@ abstract contract rulesEngineInternalFunctions is RulesEngineCommon {
 
     function testRulesEngine_Utils_VersionCheck() public ifDeploymentTestsEnabled endWithStopPrank {
         // Read the version from package.json at compile time using foundry's ffi cheatcode
-        string[] memory cmds = new string[](5);
+        string[] memory cmds = new string[](3);
         cmds[0] = "node";
         cmds[1] = "-e";
         cmds[2] = "console.log(require('./package.json').version)";

--- a/test/execution/rulesEngineInternalFunctions/rulesEngineInternalFunctions.t.sol
+++ b/test/execution/rulesEngineInternalFunctions/rulesEngineInternalFunctions.t.sol
@@ -1743,7 +1743,13 @@ abstract contract rulesEngineInternalFunctions is RulesEngineCommon {
     }
 
     function testRulesEngine_Utils_VersionCheck() public ifDeploymentTestsEnabled endWithStopPrank {
-        vm.skip(true);
-        assertEq(RulesEngineProcessorFacet(address(red)).version(), "v0.3.1");
+        // Read the version from package.json at compile time using foundry's ffi cheatcode
+        string[] memory cmds = new string[](5);
+        cmds[0] = "node";
+        cmds[1] = "-e";
+        cmds[2] = "console.log(require('./package.json').version)";
+        bytes memory out = vm.ffi(cmds);
+        string memory version = string(abi.encodePacked("v", out));
+        assertEq(RulesEngineProcessorFacet(address(red)).version(), version);
     }
 }


### PR DESCRIPTION
- Updating the unit test to pull the version from the package.json to test the facet version against. This ensures package.json is aligned with the onchain code.